### PR TITLE
Fixed empty homebrew list when using VitaDB option

### DIFF
--- a/SHM.Utilities/BrewProvider.cs
+++ b/SHM.Utilities/BrewProvider.cs
@@ -52,7 +52,11 @@ namespace SHM.Utilities
         public async Task<IEnumerable<RawVitaDbBrew>> RetrieveRawFromVitaDbAsync(string source = null)
         {
             source = source ?? Constants.VitaDBBrewsListUri;
-            return await Try.ItAsync(async () => await source.GetJsonAsync<List<RawVitaDbBrew>>()) ?? new List<RawVitaDbBrew>();
+            return await Try.ItAsync(async () => 
+                await source
+                    .WithHeader("User-Agent", "Other")
+                    .GetJsonAsync<List<RawVitaDbBrew>>())
+                ?? new List<RawVitaDbBrew>();
         }
 
         public bool IsKindRetrievable(BrewKind kind)

--- a/SHM/FormGetHomebrew.cs
+++ b/SHM/FormGetHomebrew.cs
@@ -188,6 +188,7 @@ namespace SHM
                 try
                 {
                     WebClient wc = new WebClient();
+                    wc.Headers.Add("User-Agent: Other");
                     string content = wc.DownloadString(new Uri(path));
                     wc.Dispose();
                     content = Encoding.UTF8.GetString(Encoding.Default.GetBytes(content));

--- a/SHM/FormGetHomebrew.cs
+++ b/SHM/FormGetHomebrew.cs
@@ -137,6 +137,7 @@ namespace SHM
                 try
                 {
                     WebClient wc = new WebClient();
+                    wc.Headers.Add("User-Agent: Other");   
                     string content = wc.DownloadString(new Uri(path));
                     wc.Dispose();
                     content = Encoding.UTF8.GetString(Encoding.Default.GetBytes(content));


### PR DESCRIPTION
Error 403 appeared when trying to download JSON from VitaDB.
This is fixed by adding "User-Agent: Other" header to HTTP client.